### PR TITLE
[subscriber] changed() is emited on subscription

### DIFF
--- a/src/contextkit-subscriber/property.cpp
+++ b/src/contextkit-subscriber/property.cpp
@@ -160,6 +160,7 @@ void PropertyMonitor::subscribe(SubscribeRequest *req)
 
     auto v = handler->subscribe();
     req->value_.set_value(v);
+    tgt->changed(v);
 }
 
 void PropertyMonitor::unsubscribe(UnsubscribeRequest *req)
@@ -479,7 +480,7 @@ ckit::Actor<ckit::PropertyMonitor> * ContextPropertyPrivate::actor()
     return ckit::PropertyMonitor::instance();
 }
 
-void ContextPropertyPrivate::changed(QVariant v)
+void ContextPropertyPrivate::changed(QVariant v) const
 {
     if (state_ == Subscribing)
         state_ = Subscribed;

--- a/src/contextkit-subscriber/property.hpp
+++ b/src/contextkit-subscriber/property.hpp
@@ -175,10 +175,10 @@ public:
 
 signals:
 
-    void valueChanged();
+    void valueChanged() const;
 
 public slots:
-    void changed(QVariant);
+    void changed(QVariant) const;
 private:
 
     enum State {


### PR DESCRIPTION
This fixes issue when data is not received when resubscription happens until
property is changed

Signed-off-by: Denis Zalevskiy denis.zalevskiy@jolla.com
