### PR TITLE
[subscriber] no rate limit, statefs should just block in poll now

### DIFF
--- a/src/contextkit-subscriber/property.hpp
+++ b/src/contextkit-subscriber/property.hpp
@@ -70,9 +70,6 @@ private:
     mutable QTimer *reopen_timer_;
     bool is_subscribed_;
     QVariant cache_;
-    unsigned rate_;
-    time_t now_;
-    unsigned max_rate_;
 };
 
 class Actor_ : public QThread


### PR DESCRIPTION
In rare cases it ends in file is not reopened if statefs is restarted or
crashed

Signed-off-by: Denis Zalevskiy denis.zalevskiy@jolla.com
